### PR TITLE
formatting to the complete version number

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -22,7 +22,7 @@ name: Build and deploy ASP.Net Core app to an Azure Web App
 env:
   AZURE_WEBAPP_NAME: HelloDallE-MTCPhilly    # set this to the name of your Azure Web App
   AZURE_WEBAPP_PACKAGE_PATH: './src/HelloDallE'      # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: '7'                 # set this to the .NET Core version to use
+  DOTNET_VERSION: '7.0.x'                 # set this to the .NET Core version to use
 
 on:
   push:


### PR DESCRIPTION
This pull request to the `.github/workflows/azure-webapps-dotnet-core.yml` file updates the .NET Core version used in the deployment process from `7` to `7.0.x`.

Main change:

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL25-R25">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Updated the .NET Core version used in the deployment process from `7` to `7.0.x`.