### PR TITLE
includes the working directory

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -21,7 +21,7 @@ name: Build and deploy ASP.Net Core app to an Azure Web App
 
 env:
   AZURE_WEBAPP_NAME: HelloDallE-MTCPhilly    # set this to the name of your Azure Web App
-  AZURE_WEBAPP_PACKAGE_PATH: './src/HelloDallE'      # set this to the path to your web app project, defaults to the repository root
+  AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
   DOTNET_VERSION: '7.0.x'                 # set this to the .NET Core version to use
 
 on:
@@ -57,9 +57,11 @@ jobs:
 
       - name: Build with dotnet
         run: dotnet build --configuration Release
+        working-directory: ./src/HelloDallE
 
       - name: dotnet publish
         run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        working-directory: ./src/HelloDallE
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This pull request updates the Azure Web Apps workflow to improve the build and publish steps. The most important change is setting the default package path to the repository root.

Main workflow change:

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL24-R24">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Updated the Azure Web Apps workflow to set the default package path to the repository root and specify the working directory for the build and publish steps. <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL24-R24">[1]</a> <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cR60-R64">[2]</a>