### PR TITLE
using publish profile for deployment auth

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -84,12 +84,12 @@ jobs:
         with:
           name: .net-app
 
-      - name: Login via Azure CLI
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # - name: Login via Azure CLI
+      #   uses: azure/login@v1
+      #   with:
+      #     client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      #     tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      #     subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           
       - name: Deploy to Azure Web App
         id: deploy-to-webapp


### PR DESCRIPTION
This pull request to the repository includes a single change to the Azure Web App deployment workflow. The change involves commenting out the Azure CLI authentication step in the `.github/workflows/azure-webapps-dotnet-core.yml` file.

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL87-R92">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Commented out the Azure CLI authentication step in the Azure Web App deployment workflow.