### PR TITLE
including the id-token on the deploy job

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -73,6 +73,7 @@ jobs:
   deploy:
     permissions:
       contents: none
+      id-token: write
     runs-on: ubuntu-latest
     needs: build
     environment:


### PR DESCRIPTION
This pull request includes a single change to the Azure Web Apps workflow. The change adds write permissions to the deployment id-token.

Main change:

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cR76">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Added write permissions to deployment id-token in Azure Web Apps workflow.