### PR TITLE
removing the environment reference

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -76,9 +76,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     needs: build
-    environment:
-      name: 'Development'
-      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+    # environment:
+    #   name: 'Development'
+    #   url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
       - name: Download artifact from build job


### PR DESCRIPTION
This pull request to the `.github/workflows/azure-webapps-dotnet-core.yml` file comments out the `environment` section in the `jobs` section to avoid setting up a development environment.

Main change:

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL79-R81">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Commented out the `environment` section in the `jobs` section to avoid setting up a development environment.