### PR TITLE
updated webapp deploy version

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -95,8 +95,7 @@ jobs:
           
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}


### PR DESCRIPTION
This pull request updates the version of the `azure/webapps-deploy` action in the Azure Web App workflow file. The update removes the `publish-profile` field and replaces it with the `package` field to specify the path to the Azure Web App package.

Main workflow file change:

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL98-L101">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Updated the version of the `azure/webapps-deploy` action from v2 to v3, replacing the `publish-profile` field with the `package` field to specify the path to the Azure Web App package.