### PR TITLE
fixing deployment issue

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: ./src/HelloDallE
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: .net-app
           path: ${{env.DOTNET_ROOT}}/myapp
@@ -82,9 +82,10 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           name: .net-app
+          path: deploy
 
       - name: Login via Azure CLI
         uses: azure/login@v1
@@ -98,5 +99,6 @@ jobs:
         uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          package: deploy
           type: zip
           clean: true


### PR DESCRIPTION
This pull request includes changes to the Azure web app deployment workflow. The most important changes include updating the artifact download and upload actions, and adding a parameter to specify the deployment package path.

Main workflow changes:

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL85-R88">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Updated the artifact download and upload actions, and added a parameter to specify the deployment package path. <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL85-R88">[1]</a> <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cR102">[2]</a> <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL68-R68">[3]</a>