### PR TITLE
provided the permissions

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -72,7 +72,7 @@ jobs:
 
   deploy:
     permissions:
-      contents: none
+      contents: read
       id-token: write
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
This pull request includes a change to update the permissions for the `deploy` job in `.github/workflows/azure-webapps-dotnet-core.yml`. The update allows read access to the repository contents while keeping the `id-token` permission unchanged.

Main change:

* <a href="diffhunk://#diff-af6fb194ed13ad7efaa06fdb31ad0cff03bf3fa6f8a603d9d9713060ec8de85cL75-R75">`.github/workflows/azure-webapps-dotnet-core.yml`</a>: Updated permissions for the `deploy` job to allow read access to the repository contents.