### PR TITLE
deleting remnant code

### DIFF
--- a/src/HelloDallE8/Components/Pages/Home.razor
+++ b/src/HelloDallE8/Components/Pages/Home.razor
@@ -81,12 +81,6 @@
 
         try
         {
-            Task.Run(async () =>
-            {
-                questString = await SKQuestions.InvokePromptAsync();
-
-            }).Wait();
-
             questString = await SKQuestions.InvokePromptAsync();
 
             Questions = JsonSerializer.Deserialize<List<QuestionViewModel>>(questString);


### PR DESCRIPTION
This pull request includes a simplification to the `Home.razor` file in the `src/HelloDallE8/Components/Pages` directory. The change removes redundant code that was invoking the `SKQuestions.InvokePromptAsync()` method twice. The method is now invoked only once, which should improve the efficiency of the code.

Simplification of code:

* [`src/HelloDallE8/Components/Pages/Home.razor`](diffhunk://#diff-d88a037e977e346757277b170cd55efd03e58960a0444617adab9fa8f86c85f1L84-L89): Removed the redundant `Task.Run()` invocation of `SKQuestions.InvokePromptAsync()`. The method is now invoked directly, simplifying the code and potentially improving performance.